### PR TITLE
Nested filter for sidebar search

### DIFF
--- a/app/views/apidoco/apis/_side_bar.html.erb
+++ b/app/views/apidoco/apis/_side_bar.html.erb
@@ -2,7 +2,7 @@
 <script type="text/ng-template" id="documentationTree">
   <a href="#{{documentation.id}}">{{documentation.name}}</a>
   <ul ng-if="documentation.children">
-    <li ng-repeat="documentation in documentation.children" ng-include="'documentationTree'">
+    <li ng-repeat="documentation in documentation.children | filter: searchKeyword" ng-include="'documentationTree'">
     </li>
   </ul>
 </script>


### PR DESCRIPTION
Search option in sidebar was showing all child elements even if only one child matches the search keyword. 