### PR TITLE
setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -24,6 +24,8 @@ jobs:
       uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
       with:
         ruby-version: 2.6
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Install dependencies
       run: bundle install
     - name: Run tests


### PR DESCRIPTION
Fixing the issue in the github actions 

Error: Unable to process command '::set-env name=PATH::/home/runner/.rubies/ruby-2.6.6/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/opt/pipx_bin:/usr/share/rust/.cargo/bin:/home/runner/.config/composer/vendor/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
